### PR TITLE
🐛 Set baseUrl

### DIFF
--- a/.changeset/spicy-rivers-lick.md
+++ b/.changeset/spicy-rivers-lick.md
@@ -1,0 +1,6 @@
+---
+'cypress-msw-interceptor': patch
+---
+
+Update README to specify Cypress baseUrl so that the service worker has loaded
+correctly.

--- a/README.md
+++ b/README.md
@@ -27,12 +27,16 @@ Then in `cypress/support/index.js` add:
 import 'cypress-msw-interceptor'
 ```
 
-Lastly we need initialize msw. Follow the guide form
+Next we need initialize msw. Follow the guide form
 [MSW website](https://mswjs.io/docs/getting-started/integrate/browser).
 
 You don't need to configure the worker or create handlers unless you want to use
 it in your application too. The integration for `cypress-msw-interceptor` will
 happen automatically by importing `cypress-msw-interceptor`.
+
+Lastly, we need to set the `baseUrl` for Cypress so that Cypress starts at the
+same address as the application so that the service worker can be registered
+correctly.
 
 ## Usage
 


### PR DESCRIPTION
Add note on `README.md` to specify `baseUrl` for Cypress so that the service worker can be loaded correctly.