### PR TITLE
fix: allow nocontent responses to work

### DIFF
--- a/cypress/integration/msw-requests.spec.js
+++ b/cypress/integration/msw-requests.spec.js
@@ -174,4 +174,19 @@ describe('MSW Requests', () => {
     })
     cy.findByText(/the outsider/i).should('be.visible')
   })
+  it('should be able to mock a response with no data', () => {
+    cy.visit('/');
+    cy.interceptRequest(
+      'GET',
+      'https://jsonplaceholder.typicode.com/nocontent',
+      (req, res, ctx) => res(ctx.status(204)),
+      'noContent',
+    )
+    cy.findByRole('button', { name: /no content/i }).click()
+    cy.waitForRequest('@noContent')
+    cy.getRequestCalls('@noContent').then(calls => {
+      expect(calls).to.have.length(1)
+    })
+    cy.findByText(/204/i).should('be.visible')
+  })
 })

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ const client = createClient({
 function App() {
   const [error, setError] = useState()
   const [data, setData] = useState()
+  const [status, setStatus] = useState();
 
   function getTodos() {
     fetch('https://jsonplaceholder.typicode.com/todos/1', {
@@ -17,7 +18,10 @@ function App() {
         'Content-Type': 'application/json',
       },
     })
-      .then(response => response.json())
+      .then(response => {
+        setStatus(response.status)
+        return response.json()
+      })
       .then(json => {
         setData(json)
       })
@@ -31,10 +35,23 @@ function App() {
       method,
       body: body && JSON.stringify(body),
     })
-      .then(response => response.json())
+      .then(response => {
+        setStatus(response.status)
+        return response.json()
+      })
       .then(json => {
         setData(json)
       })
+  }
+
+  function fetchNoContent() {
+    fetch('https://jsonplaceholder.typicode.com/nocontent').then(async response => {
+      setStatus(response.status)
+      if (!response.ok) {
+        setError(`Error: ${response.status}`)
+        return
+      }
+    })
   }
 
   function fetchError() {
@@ -54,6 +71,7 @@ function App() {
       <div className="App">
         {error && <p>{error}</p>}
         {data && <p>{JSON.stringify(data, null, 2)}</p>}
+        {status && <p data-test-id="statusCode">{status}</p> }
         <div>
           <h2>REST</h2>
           <button type="button" onClick={fetchError}>
@@ -61,6 +79,9 @@ function App() {
           </button>
           <button type="button" onClick={getTodos}>
             Refetch
+          </button>
+          <button type="button" onClick={fetchNoContent}>
+            No Content
           </button>
           <button type="button" onClick={() => fetchMethod('GET')}>
             GET

--- a/src/support.js
+++ b/src/support.js
@@ -107,7 +107,7 @@ async function completeGenericRequest(
 ) {
   const cloned = response.clone()
 
-  const body = await cloned.body
+  const body = cloned.body ? await cloned.body
     .getReader()
     .read()
     .then(({ value }) => {
@@ -117,7 +117,7 @@ async function completeGenericRequest(
       } catch (err) {
         return text
       }
-    })
+    }) : undefined
 
   const meta = requestTypes[requestId]
   if (!meta) return


### PR DESCRIPTION
Currently cypress-msw-interceptor causes errors if it intercepts stub response of 204 No Content.

this fixes that