### PR TITLE
feat: add options configuration object

### DIFF
--- a/src/support.js
+++ b/src/support.js
@@ -3,6 +3,7 @@ require('cypress-wait-until')
 const { setupWorker, rest, graphql } = require('msw')
 const { match } = require('node-match-path')
 const { last } = Cypress._
+import * as fs from 'fs'
 
 const REQUEST_TYPES = {
   DEFAULT: 'DEFAULT',
@@ -18,6 +19,12 @@ let queries = {}
 let routes = new Set()
 let requestMap = {}
 let aliases = {}
+let workerOptions = {}
+let workerOptionsPath = process.env.MSW_WORKER_OPTIONS_PATH
+
+if (fs.existsSync(workerOptionsPath)){
+  workerOptions = fs.readFileSync(require.resolve(workerOptionsPath))
+}
 
 function requestKey(request) {
   return Array.from(routes).find(i => {
@@ -187,7 +194,7 @@ before(() => {
   worker.events.on('request:start', registerRequest)
   worker.events.on('response:mocked', completeRequest)
   worker.events.on('response:bypass', completeRequest)
-  cy.wrap(worker.start(), { log: false })
+  cy.wrap(worker.start(workerOptions), { log: false })
 })
 
 Cypress.on('test:before:run', () => {


### PR DESCRIPTION
I need to be able to configure the worker options (we are using a different baseurl than '/' to serve our `mockServiceWorker.js` script from) that are passed to `worker.start()`. I was going to do this through creating a JSON file that could be read into memory but I was unable to make `fs.readFileSync` work here. I'm going to leave this for now and fork the repo with a hard coded options object, but I figured I'd bring it up here for anyone else seeing [this issue](https://github.com/deshiknaves/cypress-msw-interceptor/issues/14).

For the record the error I'm getting here is

```
fs.existsSync is not a function
```

And the change I'm looking to hard code: 

original 
```javascript
  cy.wrap(worker.start(), { log: false })
```

desired
```javascript
  cy.wrap(worker.start({
    onUnhandledRequest: 'bypass',
    serviceWorker: {
      url: '/myURL/mockServiceWorker.js',
      options: {
        scope: '/myURL/',
      },
    },
  }), { log: false })
```